### PR TITLE
aaaUser:pwdSet is implicit(oper) attribute

### DIFF
--- a/nxtoolkit/nxtoolkit.py
+++ b/nxtoolkit/nxtoolkit.py
@@ -6059,9 +6059,6 @@ class AaaUser(BaseNXObject):
         att['name'] = self.name
         if self.password:
             att['pwd'] = self.password
-            att['pwdSet'] = 'yes'
-        else:
-            att['pwdSet'] = 'no'
         return att
     
     def _get_child_attributes(self):


### PR DESCRIPTION
aaaUser:pwdSet is implicit(oper) attribute, it should not be read-only.